### PR TITLE
Add the missing DELETE /job/{id} operation

### DIFF
--- a/petsitter.0.0.oas.yml
+++ b/petsitter.0.0.oas.yml
@@ -112,6 +112,11 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Job'    
+    delete:
+      summary: Delete Job
+      responses:
+        '204':
+          description: No Content
   /jobs/{id}/job-applications:
     parameters:
       - schema:


### PR DESCRIPTION
Add the missing `DELETE /job/{id}` operation.
I believe we'll need this when the user wants to delete the Job from the service.
